### PR TITLE
PR for Issue #3

### DIFF
--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -18,39 +18,49 @@ AuthTokenRefresh._strategies = {};
  * @param {String|Strategy} name
  * @param {Strategy} passport strategy
  */
-AuthTokenRefresh.use = function(name, strategy) {
-  if(arguments.length === 1) {
+AuthTokenRefresh.use = function (name, strategy) {
+  if (arguments.length === 1) {
     // Infer name from strategy
     strategy = name;
     name = strategy && strategy.name;
   }
-
+  
   /* jshint eqnull: true */
-  if(strategy == null) {
+  if (strategy == null) {
     throw new Error('Cannot register: strategy is null');
   }
   /* jshint eqnull: false */
 
-  if(!name) {
+  if (!name) {
     throw new Error('Cannot register: name must be specified, or strategy must include name');
   }
 
-  if(!strategy._oauth2) {
+  if (!strategy._oauth2) {
     throw new Error('Cannot register: not an OAuth2 strategy');
   }
-
+  
+  // default to using the strategy's oauth2 instance unless the _refreshURL
+  // has been specified, then we need to create a new instance and set the
+  // accessTokenUrl to be the strategy provided _refreshUrl.
+  var oAuth2;
+  if (strategy._refreshURL) {
+    oAuth2 = new OAuth2(
+      strategy._oauth2._clientId,
+      strategy._oauth2._clientSecret,
+      strategy._oauth2._baseSite,
+      strategy._oauth2._authorizeUrl,
+      strategy._refreshURL,
+      strategy._oauth2._customHeaders);
+  } else {
+    oAuth2 = strategy._oauth2;
+  }
+  
   // Generate our own oauth2 object for use later.
   // Use the strategy's _refreshURL, if defined,
   // otherwise use the regular accessTokenUrl.
   AuthTokenRefresh._strategies[name] = {
     strategy: strategy,
-    refreshOAuth2: new OAuth2(
-      strategy._oauth2._clientId,
-      strategy._oauth2._clientSecret,
-      strategy._oauth2._baseSite,
-      strategy._oauth2._authorizeUrl,
-      strategy._refreshURL || strategy._oauth2._accessTokenUrl,
-      strategy._oauth2._customHeaders)
+    refreshOAuth2: oAuth2
   };
 };
 
@@ -59,7 +69,7 @@ AuthTokenRefresh.use = function(name, strategy) {
  * @param  {String}  name Strategy name
  * @return {Boolean}
  */
-AuthTokenRefresh.has = function(name) {
+AuthTokenRefresh.has = function (name) {
   return !!AuthTokenRefresh._strategies[name];
 };
 
@@ -72,11 +82,11 @@ AuthTokenRefresh.has = function(name) {
  *                                 a new access token.
  * @param  {Function} done         Callback when all is done.
  */
-AuthTokenRefresh.requestNewAccessToken = function(name, refreshToken, done) {
+AuthTokenRefresh.requestNewAccessToken = function (name, refreshToken, done) {
   // Send a request to refresh an access token, and call the passed
   // callback with the result.
   var strategy = AuthTokenRefresh._strategies[name];
-  if(!strategy) {
+  if (!strategy) {
     return done(new Error('Strategy was not registered to refresh a token'));
   }
 


### PR DESCRIPTION
By default, use the strategy's _oauth2, unless a refreshURL has been provided by the client, in which case create a copy and use that.