### PR TITLE
set getOAuthAccessToken to whatever the strategy uses

### DIFF
--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -55,7 +55,7 @@ AuthTokenRefresh.use = function(name, strategy) {
       strategy._oauth2._customHeaders)
   };
   
-  // Some strategies use overwrite the getOAuthAccessToken function to set headers
+  // Some strategies overwrite the getOAuthAccessToken function to set headers
   // https://github.com/fiznool/passport-oauth2-refresh/issues/10
   AuthTokenRefresh._strategies[name].refreshOAuth2.getOAuthAccessToken = strategy._oauth2.getOAuthAccessToken;
 };

--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -54,6 +54,10 @@ AuthTokenRefresh.use = function(name, strategy) {
       strategy._refreshURL || strategy._oauth2._accessTokenUrl,
       strategy._oauth2._customHeaders)
   };
+  
+  // Some strategies use overwrite the getOAuthAccessToken function to set headers
+  // https://github.com/fiznool/passport-oauth2-refresh/issues/10
+  AuthTokenRefresh._strategies[name].refreshOAuth2.getOAuthAccessToken = strategy._oauth2.getOAuthAccessToken;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   },
   "homepage": "https://github.com/fiznool/passport-oauth2-refresh",
   "devDependencies": {
-    "chai": "*",
-    "mocha": "*",
-    "sinon": "*",
-    "sinon-chai": "*"
+    "chai": "^3.4.1",
+    "mocha": "^2.3.4",
+    "sinon": "^1.17.2",
+    "sinon-chai": "^2.8.0"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/test/refresh.spec.js
+++ b/test/refresh.spec.js
@@ -125,7 +125,7 @@ describe('Auth token refresh', function() {
     it('should use the default getOAuthAccessToken function if not overwritten by strategy', function() {
       var strategy = {
         name: 'test_strategy',
-        _oauth2: newOAuth2('accessTokenUrl')
+        _oauth2: newOAuth2()
       };
 
       AuthTokenRefresh.use(strategy);
@@ -135,7 +135,7 @@ describe('Auth token refresh', function() {
     it('should use the overwritten getOAuthAccessToken function if overwritten by strategy', function() {
       var strategy = {
         name: 'test_strategy',
-        _oauth2: newOAuth2('accessTokenUrl')
+        _oauth2: newOAuth2()
       };
       
       strategy._oauth2.getOAuthAccessToken = new Function();

--- a/test/refresh.spec.js
+++ b/test/refresh.spec.js
@@ -14,6 +14,9 @@ function OAuth2(clientId, clientSecret, baseSite, authorizeUrl, accessTokenUrl) 
   this._accessTokenUrl = accessTokenUrl;
 }
 
+// Add dummy method
+OAuth2.prototype.getOAuthAccessToken = new Function();
+
 // Makes it easy to invocate in the specs
 var newOAuth2 = function(accessTokenUrl) {
   return new OAuth2(null, null, null, null, accessTokenUrl);
@@ -117,6 +120,29 @@ describe('Auth token refresh', function() {
       };
 
       expect(fn).to.throw(Error, 'Cannot register: not an OAuth2 strategy');
+    });
+    
+    it('should use the default getOAuthAccessToken function if not overwritten by strategy', function() {
+      var strategy = {
+        name: 'test_strategy',
+        _oauth2: newOAuth2('accessTokenUrl')
+      };
+
+      AuthTokenRefresh.use(strategy);
+      expect(AuthTokenRefresh._strategies.test_strategy.refreshOAuth2.getOAuthAccessToken).to.equal(OAuth2.prototype.getOAuthAccessToken);
+    });
+
+    it('should use the overwritten getOAuthAccessToken function if overwritten by strategy', function() {
+      var strategy = {
+        name: 'test_strategy',
+        _oauth2: newOAuth2('accessTokenUrl')
+      };
+      
+      strategy._oauth2.getOAuthAccessToken = new Function();
+
+      AuthTokenRefresh.use(strategy);
+      expect(AuthTokenRefresh._strategies.test_strategy.refreshOAuth2.getOAuthAccessToken).to.equal(strategy._oauth2.getOAuthAccessToken);
+      expect(AuthTokenRefresh._strategies.test_strategy.refreshOAuth2.getOAuthAccessToken).not.equal(OAuth2.prototype.getOAuthAccessToken);
     });
   });
 


### PR DESCRIPTION
This PR sets the `getOAuthAccessToken` function to what the strategy uses, whether it's from the original `oauth` module or overwritten in the strategy.

Tested this on strategies that do overwrite the function, as well as on strategies that do not.