### PR TITLE
optional proxy argument added to "use" function

### DIFF
--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -52,10 +52,8 @@ AuthTokenRefresh.use = function (name, strategy, agent) {
     throw new Error('Cannot register: not an OAuth2 strategy');
   }
 
-  if (agent && typeof agent === 'string') {
-    throw new Error(
-      'Please provide a HttpsProxyAgent instance instead of a proxy string',
-    );
+  if (agent && typeof agent !== 'object') {
+    throw new Error('Please provide a HttpsProxyAgent instance');
   }
 
   // Use the strategy's OAuth2 object, since it might have been overwritten.

--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -12,15 +12,30 @@ AuthTokenRefresh._strategies = {};
  *
  *     refresh.use(strategy);
  *     refresh.use('facebook', strategy);
+ *     refresh.use(strategy, new HttpsProxyAgent("your.proxy:port"))
  *
  * @param {String|Strategy} name
  * @param {Strategy} passport strategy
+ * @param {HttpsProxyAgent} agent
  */
-AuthTokenRefresh.use = function (name, strategy) {
-  if (arguments.length === 1) {
-    // Infer name from strategy
-    strategy = name;
-    name = strategy && strategy.name;
+AuthTokenRefresh.use = function (name, strategy, agent) {
+  switch (arguments.length) {
+    case 1:
+      // Infer name from strategy
+      strategy = name;
+      name = strategy && strategy.name;
+      break;
+    case 2:
+      // When using with proxy without a name
+      if (typeof name !== 'string') {
+        agent = strategy;
+
+        // Infer strategy from agent
+        strategy = name;
+        name = strategy && strategy.name;
+      }
+
+      break;
   }
 
   if (strategy == null) {
@@ -35,6 +50,12 @@ AuthTokenRefresh.use = function (name, strategy) {
 
   if (!strategy._oauth2) {
     throw new Error('Cannot register: not an OAuth2 strategy');
+  }
+
+  if (agent && typeof agent === 'string') {
+    throw new Error(
+      'Please provide a HttpsProxyAgent instance instead of a proxy string',
+    );
   }
 
   // Use the strategy's OAuth2 object, since it might have been overwritten.
@@ -55,6 +76,10 @@ AuthTokenRefresh.use = function (name, strategy) {
       strategy._oauth2._customHeaders,
     ),
   };
+
+  if (agent !== undefined) {
+    AuthTokenRefresh._strategies[name].refreshOAuth2.setAgent(agent);
+  }
 
   // Some strategies overwrite the getOAuthAccessToken function to set headers
   // https://github.com/fiznool/passport-oauth2-refresh/issues/10


### PR DESCRIPTION
Resolves #9 
The "use" function now receives a third "agent" parameter which should be the type of [HttpsProxyAgent](https://www.npmjs.com/package/https-proxy-agent).
Added a switch case to handle the case where two parameters (strategy, agent) are sent (without the name param).
After the initialization of the current strategy, checks if there is an existing agent, and if there is, it sets it as the agent for the OAuth2 instance. 