### PR TITLE
Support for multiple distinct instances, as in Passport itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.2.0] - 2023-04-06
+## Unreleased
 
 ### Added
 
-- In addition to exporting an object that can be immediately used,
-  just as before, we have added an `AuthTokenRefresh` property. This is a
+- Added a new named export `AuthTokenRefresh`. This is a
   constructor that can be invoked to create a distinct instance, for
-  applications that require more than one passport instance. (Passport has the same feature.)
+  applications that require more than one Passport instance.
 
 ## [2.1.0] - 2021-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.0] - 2023-04-06
+
+### Added
+
+- In addition to exporting an object that can be immediately used,
+  just as before, we have added an `AuthTokenRefresh` property. This is a
+  constructor that can be invoked to create a distinct instance, for
+  applications that require more than one passport instance. (Passport has the same feature.)
+
 ## [2.1.0] - 2021-06-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -113,6 +113,23 @@ const extraParams = { some: 'extra_param' };
 refresh.requestNewAccessToken('gmail', 'some_refresh_token', extraParams, done);
 ```
 
+### Multiple instances
+
+Projects that need multiple instances of Passport can construct them using the `Passport`
+constructor available on the `passport` module. Similarly, this module provides
+an `AuthTokenRefresh` constructor that can be used instead of the single instance provided
+by default.
+
+```javascript
+const { Passport } = require('passport');
+const { AuthTokenRefresh } = require('passport-oauth2-refresh');
+
+const passport = new Passport();
+const refresh = new AuthTokenRefresh();
+
+// Additional, distinct instances of these modules can also be created
+```
+
 ## Examples
 
 - See [issue #1](https://github.com/fiznool/passport-oauth2-refresh/issues/1) for an example of how to refresh a token when requesting data from the Google APIs.

--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -1,14 +1,9 @@
 'use strict';
 
-// Default export, for typical case & backwards compatibility
-module.exports = new AuthTokenRefresh();
-
-// Export a constructor, just like Passport does
-module.exports.AuthTokenRefresh = AuthTokenRefresh;
-
-function AuthTokenRefresh() {
-  this._strategies = {};
-
+class AuthTokenRefresh {
+  constructor() {
+    this._strategies = {};
+  }
   /**
    * Register a passport strategy so it can refresh an access token,
    * with optional `name`, overridding the strategy's default name.
@@ -34,7 +29,7 @@ function AuthTokenRefresh() {
    * @param {Object} options
    * @param {OAuth2} options.setRefreshOAuth2 a callback to modify the oauth2 adapter. Should return the oauth2 adapter to use when refreshing the token.
    */
-  this.use = function (name, strategy, options) {
+  use(name, strategy, options) {
     if (typeof name !== 'string') {
       // Infer name from strategy
       options = strategy;
@@ -98,16 +93,16 @@ function AuthTokenRefresh() {
       strategy,
       refreshOAuth2,
     };
-  };
+  }
 
   /**
    * Check if a strategy is registered for refreshing.
    * @param  {String}  name Strategy name
    * @return {Boolean}
    */
-  this.has = function (name) {
+  has(name) {
     return !!this._strategies[name];
-  };
+  }
 
   /**
    * Request a new access token, using the passed refreshToken,
@@ -120,7 +115,7 @@ function AuthTokenRefresh() {
    *                                 params to use when requesting the token.
    * @param  {Function} done         Callback when all is done.
    */
-  this.requestNewAccessToken = function (name, refreshToken, params, done) {
+  requestNewAccessToken(name, refreshToken, params, done) {
     if (arguments.length === 3) {
       done = params;
       params = {};
@@ -137,5 +132,11 @@ function AuthTokenRefresh() {
     params.grant_type = 'refresh_token';
 
     strategy.refreshOAuth2.getOAuthAccessToken(refreshToken, params, done);
-  };
+  }
 }
+
+// Default export, for typical case & backwards compatibility
+module.exports = new AuthTokenRefresh();
+
+// Export a constructor, just like Passport does
+module.exports.AuthTokenRefresh = AuthTokenRefresh;

--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -1,142 +1,141 @@
 'use strict';
 
-const AuthTokenRefresh = {};
+// Default export, for typical case & backwards compatibility
+module.exports = new AuthTokenRefresh();
 
-AuthTokenRefresh._strategies = {};
+// Export a constructor, just like Passport does
+module.exports.AuthTokenRefresh = AuthTokenRefresh;
 
-/**
- * Register a passport strategy so it can refresh an access token,
- * with optional `name`, overridding the strategy's default name.
- *
- * A third optional options parameter is available, which can be
- * used to create a custom OAuth2 adapter, or modify the one
- * which is automatically created. This is useful if the
- * strategy does not expose its internal OAuth2 adapter, or
- * customizes the adapter in some way that needs to be replicated.
- *
- * Examples:
- *
- *     refresh.use(strategy);
- *     refresh.use('facebook', strategy);
- *     refresh.use('activedirectory', strategy, {
- *       setRefreshOAuth2() {
- *         return new OAuth2(...);
- *       }
- *     });
- *
- * @param {String|Strategy} name
- * @param {Strategy} passport strategy
- * @param {Object} options
- * @param {OAuth2} options.setRefreshOAuth2 a callback to modify the oauth2 adapter. Should return the oauth2 adapter to use when refreshing the token.
- */
-AuthTokenRefresh.use = function (name, strategy, options) {
-  if (typeof name !== 'string') {
-    // Infer name from strategy
-    options = strategy;
-    strategy = name;
-    name = strategy && strategy.name;
-  }
+function AuthTokenRefresh() {
+  this._strategies = {};
 
-  if (strategy == null) {
-    throw new Error('Cannot register: strategy is null');
-  }
+  /**
+   * Register a passport strategy so it can refresh an access token,
+   * with optional `name`, overridding the strategy's default name.
+   *
+   * A third optional options parameter is available, which can be
+   * used to create a custom OAuth2 adapter, or modify the one
+   * which is automatically created. This is useful if the
+   * strategy does not expose its internal OAuth2 adapter, or
+   * customizes the adapter in some way that needs to be replicated.
+   *
+   * Examples:
+   *
+   *     refresh.use(strategy);
+   *     refresh.use('facebook', strategy);
+   *     refresh.use('activedirectory', strategy, {
+   *       setRefreshOAuth2() {
+   *         return new OAuth2(...);
+   *       }
+   *     });
+   *
+   * @param {String|Strategy} name
+   * @param {Strategy} passport strategy
+   * @param {Object} options
+   * @param {OAuth2} options.setRefreshOAuth2 a callback to modify the oauth2 adapter. Should return the oauth2 adapter to use when refreshing the token.
+   */
+  this.use = function (name, strategy, options) {
+    if (typeof name !== 'string') {
+      // Infer name from strategy
+      options = strategy;
+      strategy = name;
+      name = strategy && strategy.name;
+    }
 
-  if (!name) {
-    throw new Error(
-      'Cannot register: name must be specified, or strategy must include name',
-    );
-  }
+    if (strategy == null) {
+      throw new Error('Cannot register: strategy is null');
+    }
 
-  options = options || {};
+    if (!name) {
+      throw new Error(
+        'Cannot register: name must be specified, or strategy must include name',
+      );
+    }
 
-  let refreshOAuth2 = undefined;
+    options = options || {};
 
-  if (strategy._oauth2) {
-    // Try to use the internal oauth2 adapter, setting some sane defaults.
-    // Use the strategy's OAuth2 object, since it might have been overwritten.
-    // https://github.com/fiznool/passport-oauth2-refresh/issues/3
-    const OAuth2 = strategy._oauth2.constructor;
+    let refreshOAuth2 = undefined;
 
-    // Generate our own oauth2 object for use later.
-    // Use the strategy's _refreshURL, if defined,
-    // otherwise use the regular accessTokenUrl.
-    refreshOAuth2 = new OAuth2(
-      strategy._oauth2._clientId,
-      strategy._oauth2._clientSecret,
-      strategy._oauth2._baseSite,
-      strategy._oauth2._authorizeUrl,
-      strategy._refreshURL || strategy._oauth2._accessTokenUrl,
-      strategy._oauth2._customHeaders,
-    );
+    if (strategy._oauth2) {
+      // Try to use the internal oauth2 adapter, setting some sane defaults.
+      // Use the strategy's OAuth2 object, since it might have been overwritten.
+      // https://github.com/fiznool/passport-oauth2-refresh/issues/3
+      const OAuth2 = strategy._oauth2.constructor;
 
-    // Some strategies overwrite the getOAuthAccessToken function to set headers
-    // https://github.com/fiznool/passport-oauth2-refresh/issues/10
-    refreshOAuth2.getOAuthAccessToken = strategy._oauth2.getOAuthAccessToken;
-  }
+      // Generate our own oauth2 object for use later.
+      // Use the strategy's _refreshURL, if defined,
+      // otherwise use the regular accessTokenUrl.
+      refreshOAuth2 = new OAuth2(
+        strategy._oauth2._clientId,
+        strategy._oauth2._clientSecret,
+        strategy._oauth2._baseSite,
+        strategy._oauth2._authorizeUrl,
+        strategy._refreshURL || strategy._oauth2._accessTokenUrl,
+        strategy._oauth2._customHeaders,
+      );
 
-  // See if we need to customise the OAuth2 object any further
-  if (typeof options.setRefreshOAuth2 === 'function') {
-    refreshOAuth2 = options.setRefreshOAuth2({
-      strategyOAuth2: strategy._oauth2,
+      // Some strategies overwrite the getOAuthAccessToken function to set headers
+      // https://github.com/fiznool/passport-oauth2-refresh/issues/10
+      refreshOAuth2.getOAuthAccessToken = strategy._oauth2.getOAuthAccessToken;
+    }
+
+    // See if we need to customise the OAuth2 object any further
+    if (typeof options.setRefreshOAuth2 === 'function') {
+      refreshOAuth2 = options.setRefreshOAuth2({
+        strategyOAuth2: strategy._oauth2,
+        refreshOAuth2,
+      });
+    }
+
+    if (!refreshOAuth2) {
+      throw new Error(
+        'The OAuth2 adapter used to refresh the token is not configured correctly. Use the setRefreshOAuth2 option to return a OAuth 2.0 adapter.',
+      );
+    }
+
+    // Set the strategy and oauth2 adapter for use later
+    this._strategies[name] = {
+      strategy,
       refreshOAuth2,
-    });
-  }
-
-  if (!refreshOAuth2) {
-    throw new Error(
-      'The OAuth2 adapter used to refresh the token is not configured correctly. Use the setRefreshOAuth2 option to return a OAuth 2.0 adapter.',
-    );
-  }
-
-  // Set the strategy and oauth2 adapter for use later
-  AuthTokenRefresh._strategies[name] = {
-    strategy,
-    refreshOAuth2,
+    };
   };
-};
 
-/**
- * Check if a strategy is registered for refreshing.
- * @param  {String}  name Strategy name
- * @return {Boolean}
- */
-AuthTokenRefresh.has = function (name) {
-  return !!AuthTokenRefresh._strategies[name];
-};
+  /**
+   * Check if a strategy is registered for refreshing.
+   * @param  {String}  name Strategy name
+   * @return {Boolean}
+   */
+  this.has = function (name) {
+    return !!this._strategies[name];
+  };
 
-/**
- * Request a new access token, using the passed refreshToken,
- * for the given strategy.
- * @param  {String}   name         Strategy name. Must have already
- *                                 been registered.
- * @param  {String}   refreshToken Refresh token to be sent to request
- *                                 a new access token.
- * @param  {Object}   params       (optional) an object containing additional
- *                                 params to use when requesting the token.
- * @param  {Function} done         Callback when all is done.
- */
-AuthTokenRefresh.requestNewAccessToken = function (
-  name,
-  refreshToken,
-  params,
-  done,
-) {
-  if (arguments.length === 3) {
-    done = params;
-    params = {};
-  }
+  /**
+   * Request a new access token, using the passed refreshToken,
+   * for the given strategy.
+   * @param  {String}   name         Strategy name. Must have already
+   *                                 been registered.
+   * @param  {String}   refreshToken Refresh token to be sent to request
+   *                                 a new access token.
+   * @param  {Object}   params       (optional) an object containing additional
+   *                                 params to use when requesting the token.
+   * @param  {Function} done         Callback when all is done.
+   */
+  this.requestNewAccessToken = function (name, refreshToken, params, done) {
+    if (arguments.length === 3) {
+      done = params;
+      params = {};
+    }
 
-  // Send a request to refresh an access token, and call the passed
-  // callback with the result.
-  const strategy = AuthTokenRefresh._strategies[name];
-  if (!strategy) {
-    return done(new Error('Strategy was not registered to refresh a token'));
-  }
+    // Send a request to refresh an access token, and call the passed
+    // callback with the result.
+    const strategy = this._strategies[name];
+    if (!strategy) {
+      return done(new Error('Strategy was not registered to refresh a token'));
+    }
 
-  params = params || {};
-  params.grant_type = 'refresh_token';
+    params = params || {};
+    params.grant_type = 'refresh_token';
 
-  strategy.refreshOAuth2.getOAuthAccessToken(refreshToken, params, done);
-};
-
-module.exports = AuthTokenRefresh;
+    strategy.refreshOAuth2.getOAuthAccessToken(refreshToken, params, done);
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "passport-oauth2-refresh",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.2",
+      "name": "passport-oauth2-refresh",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "chai": "^4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "passport-oauth2-refresh",
-  "version": "2.1.0",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "passport-oauth2-refresh",
-      "version": "2.1.0",
+      "version": "2.0.2",
       "license": "MIT",
       "devDependencies": {
         "chai": "^4.3.4",

--- a/test/refresh.spec.js
+++ b/test/refresh.spec.js
@@ -5,7 +5,9 @@ require('mocha');
 const chai = require('chai');
 const sinon = require('sinon');
 const expect = chai.expect;
-const AuthTokenRefresh = require('../lib/refresh.js');
+const refresh = require('../lib/refresh.js');
+// Constructor, for additional distinct instances
+const AuthTokenRefresh = refresh.AuthTokenRefresh;
 
 chai.use(require('sinon-chai'));
 
@@ -30,7 +32,7 @@ const newOAuth2 = function (accessTokenUrl) {
 
 describe('Auth token refresh', function () {
   beforeEach(function () {
-    AuthTokenRefresh._strategies = {};
+    refresh._strategies = {};
   });
 
   describe('use', function () {
@@ -40,12 +42,10 @@ describe('Auth token refresh', function () {
         _oauth2: newOAuth2(),
       };
 
-      AuthTokenRefresh.use('explicit_name', strategy);
+      refresh.use('explicit_name', strategy);
 
-      expect(AuthTokenRefresh._strategies.explicit_name.strategy).to.equal(
-        strategy,
-      );
-      expect(AuthTokenRefresh._strategies.strategy).to.be.undefined;
+      expect(refresh._strategies.explicit_name.strategy).to.equal(strategy);
+      expect(refresh._strategies.strategy).to.be.undefined;
     });
 
     it('should add a strategy without an explicitly defined name', function () {
@@ -54,11 +54,9 @@ describe('Auth token refresh', function () {
         _oauth2: newOAuth2(),
       };
 
-      AuthTokenRefresh.use(strategy);
+      refresh.use(strategy);
 
-      expect(AuthTokenRefresh._strategies.internal_name.strategy).to.equal(
-        strategy,
-      );
+      expect(refresh._strategies.internal_name.strategy).to.equal(strategy);
     });
 
     it('should add a strategy with a refreshURL', function () {
@@ -68,13 +66,10 @@ describe('Auth token refresh', function () {
         _oauth2: newOAuth2('accessTokenUrl'),
       };
 
-      AuthTokenRefresh.use(strategy);
-      expect(AuthTokenRefresh._strategies.test_strategy.strategy).to.equal(
-        strategy,
-      );
+      refresh.use(strategy);
+      expect(refresh._strategies.test_strategy.strategy).to.equal(strategy);
       expect(
-        AuthTokenRefresh._strategies.test_strategy.refreshOAuth2
-          ._accessTokenUrl,
+        refresh._strategies.test_strategy.refreshOAuth2._accessTokenUrl,
       ).to.equal('refreshURL');
     });
 
@@ -84,13 +79,10 @@ describe('Auth token refresh', function () {
         _oauth2: newOAuth2('accessTokenUrl'),
       };
 
-      AuthTokenRefresh.use(strategy);
-      expect(AuthTokenRefresh._strategies.test_strategy.strategy).to.equal(
-        strategy,
-      );
+      refresh.use(strategy);
+      expect(refresh._strategies.test_strategy.strategy).to.equal(strategy);
       expect(
-        AuthTokenRefresh._strategies.test_strategy.refreshOAuth2
-          ._accessTokenUrl,
+        refresh._strategies.test_strategy.refreshOAuth2._accessTokenUrl,
       ).to.equal('accessTokenUrl');
     });
 
@@ -101,13 +93,13 @@ describe('Auth token refresh', function () {
         _oauth2: strategyOAuth2,
       };
 
-      AuthTokenRefresh.use(strategy);
-      expect(
-        AuthTokenRefresh._strategies.test_strategy.refreshOAuth2,
-      ).to.not.equal(strategyOAuth2);
-      expect(
-        AuthTokenRefresh._strategies.test_strategy.refreshOAuth2,
-      ).to.be.instanceof(OAuth2);
+      refresh.use(strategy);
+      expect(refresh._strategies.test_strategy.refreshOAuth2).to.not.equal(
+        strategyOAuth2,
+      );
+      expect(refresh._strategies.test_strategy.refreshOAuth2).to.be.instanceof(
+        OAuth2,
+      );
     });
 
     it('should set the oauth2 adapter with the options object', function () {
@@ -119,7 +111,7 @@ describe('Auth token refresh', function () {
       };
       const setRefreshOAuth2 = sinon.fake.returns(customOAuth2);
 
-      AuthTokenRefresh.use(strategy, {
+      refresh.use(strategy, {
         setRefreshOAuth2,
       });
 
@@ -127,7 +119,7 @@ describe('Auth token refresh', function () {
         strategyOAuth2,
         refreshOAuth2: sinon.match.instanceOf(OAuth2),
       });
-      expect(AuthTokenRefresh._strategies.test_strategy.refreshOAuth2).to.equal(
+      expect(refresh._strategies.test_strategy.refreshOAuth2).to.equal(
         customOAuth2,
       );
     });
@@ -138,7 +130,7 @@ describe('Auth token refresh', function () {
       };
 
       const fn = function () {
-        AuthTokenRefresh.use(strategy);
+        refresh.use(strategy);
       };
 
       expect(fn).to.throw(
@@ -154,7 +146,7 @@ describe('Auth token refresh', function () {
       const modifyOAuth2 = sinon.fake.returns(undefined);
 
       const fn = function () {
-        AuthTokenRefresh.use(strategy, {
+        refresh.use(strategy, {
           modifyOAuth2,
         });
       };
@@ -168,7 +160,7 @@ describe('Auth token refresh', function () {
     it('should not add a null strategy', function () {
       const strategy = null;
       const fn = function () {
-        AuthTokenRefresh.use(strategy);
+        refresh.use(strategy);
       };
 
       expect(fn).to.throw(Error, 'Cannot register: strategy is null');
@@ -181,7 +173,7 @@ describe('Auth token refresh', function () {
       };
 
       const fn = function () {
-        AuthTokenRefresh.use(strategy);
+        refresh.use(strategy);
       };
 
       expect(fn).to.throw(
@@ -196,10 +188,9 @@ describe('Auth token refresh', function () {
         _oauth2: newOAuth2(),
       };
 
-      AuthTokenRefresh.use(strategy);
+      refresh.use(strategy);
       expect(
-        AuthTokenRefresh._strategies.test_strategy.refreshOAuth2
-          .getOAuthAccessToken,
+        refresh._strategies.test_strategy.refreshOAuth2.getOAuthAccessToken,
       ).to.equal(OAuth2.prototype.getOAuthAccessToken);
     });
 
@@ -211,14 +202,12 @@ describe('Auth token refresh', function () {
 
       strategy._oauth2.getOAuthAccessToken = new Function();
 
-      AuthTokenRefresh.use(strategy);
+      refresh.use(strategy);
       expect(
-        AuthTokenRefresh._strategies.test_strategy.refreshOAuth2
-          .getOAuthAccessToken,
+        refresh._strategies.test_strategy.refreshOAuth2.getOAuthAccessToken,
       ).to.equal(strategy._oauth2.getOAuthAccessToken);
       expect(
-        AuthTokenRefresh._strategies.test_strategy.refreshOAuth2
-          .getOAuthAccessToken,
+        refresh._strategies.test_strategy.refreshOAuth2.getOAuthAccessToken,
       ).not.equal(OAuth2.prototype.getOAuthAccessToken);
     });
   });
@@ -230,12 +219,12 @@ describe('Auth token refresh', function () {
         _oauth2: newOAuth2(),
       };
 
-      AuthTokenRefresh.use(strategy);
-      expect(AuthTokenRefresh.has('test_strategy')).to.be.true;
+      refresh.use(strategy);
+      expect(refresh.has('test_strategy')).to.be.true;
     });
 
     it('should return false if a strategy has not been added', function () {
-      expect(AuthTokenRefresh.has('test_strategy')).to.be.false;
+      expect(refresh.has('test_strategy')).to.be.false;
     });
   });
 
@@ -244,7 +233,7 @@ describe('Auth token refresh', function () {
       const getOAuthAccessTokenSpy = sinon.spy();
       const done = sinon.spy();
 
-      AuthTokenRefresh._strategies = {
+      refresh._strategies = {
         test_strategy: {
           refreshOAuth2: {
             getOAuthAccessToken: getOAuthAccessTokenSpy,
@@ -252,11 +241,7 @@ describe('Auth token refresh', function () {
         },
       };
 
-      AuthTokenRefresh.requestNewAccessToken(
-        'test_strategy',
-        'refresh_token',
-        done,
-      );
+      refresh.requestNewAccessToken('test_strategy', 'refresh_token', done);
 
       expect(getOAuthAccessTokenSpy).to.have.been.calledWith(
         'refresh_token',
@@ -269,7 +254,7 @@ describe('Auth token refresh', function () {
       const getOAuthAccessTokenSpy = sinon.spy();
       const done = sinon.spy();
 
-      AuthTokenRefresh._strategies = {
+      refresh._strategies = {
         test_strategy: {
           refreshOAuth2: {
             getOAuthAccessToken: getOAuthAccessTokenSpy,
@@ -277,7 +262,7 @@ describe('Auth token refresh', function () {
         },
       };
 
-      AuthTokenRefresh.requestNewAccessToken(
+      refresh.requestNewAccessToken(
         'test_strategy',
         'refresh_token',
         { some: 'extra_param' },
@@ -302,13 +287,18 @@ describe('Auth token refresh', function () {
           ),
         );
 
-      AuthTokenRefresh.requestNewAccessToken(
-        'test_strategy',
-        'refresh_token',
-        done,
-      );
+      refresh.requestNewAccessToken('test_strategy', 'refresh_token', done);
 
       expect(done).to.have.been.calledWith(expected);
+    });
+  });
+
+  describe('multiple instances', function () {
+    it('should support creating a second, independent instance', function () {
+      const refresh2 = new AuthTokenRefresh();
+      expect(refresh).to.be.instanceof(AuthTokenRefresh);
+      expect(refresh2).to.be.instanceof(AuthTokenRefresh);
+      expect(refresh).to.not.equal(refresh2);
     });
   });
 });


### PR DESCRIPTION
Thanks for creating and maintaining this module!

In our application, it is necessary to have separate instances of Passport itself. Passport supports this: the default export is an instance, which makes sense for most projects, but there is a "Passport" property on that instance as well. This is a constructor that can be used to make a separate and distinct instance of Passport that doesn't share any configuration with the default one (or any others).

In this PR, I've contributed the same feature for passport-oauth2-refresh. I believe the test coverage shows the functionality hasn't changed.

Thanks for taking a look, and by all means let me know if any changes are needed etc.